### PR TITLE
Fix loading legacy floppy controller save states

### DIFF
--- a/Source/ePC-8801MA/vm/upd765a.cpp
+++ b/Source/ePC-8801MA/vm/upd765a.cpp
@@ -1677,7 +1677,8 @@ void UPD765A::save_state(FILEIO* state_fio)
 
 bool UPD765A::load_state(FILEIO* state_fio)
 {
-	if(state_fio->FgetUint32() != STATE_VERSION) {
+	const uint32 version = state_fio->FgetUint32();
+	if(version != 1 && version != STATE_VERSION) {
 		return false;
 	}
 	if(state_fio->FgetInt32() != this_device_id) {
@@ -1725,7 +1726,12 @@ bool UPD765A::load_state(FILEIO* state_fio)
 	force_ready = state_fio->FgetBool();
 	reset_signal = state_fio->FgetBool();
 	prev_index = state_fio->FgetBool();
-	state_fio->Fread(disk_exchanged, sizeof(disk_exchanged), 1);
+	if(version >= 2) {
+		state_fio->Fread(disk_exchanged, sizeof(disk_exchanged), 1);
+	} else {
+		// Version 1 predates disk-change tracking and has no flag bytes.
+		memset(disk_exchanged, 0, sizeof(disk_exchanged));
+	}
 	prev_drq_clock = state_fio->FgetUint32();
 	return true;
 }

--- a/Tests/event_host_frame_integration_test.cpp
+++ b/Tests/event_host_frame_integration_test.cpp
@@ -1,6 +1,11 @@
+#include <chrono>
+#include <string>
+#include <vector>
+
 #include "emu.h"
 #include "event.h"
 #include "pc8801.h"
+#include "fileio.h"
 
 #include <cstdio>
 #include <cstdlib>
@@ -23,6 +28,84 @@ void Require(bool condition, const char *message)
 		std::fprintf(stderr, "FAIL: %s\n", message);
 		std::exit(1);
 	}
+}
+
+
+void CheckFdcStateCompatibility(VM &vm)
+{
+	const char *temporary = std::getenv(
+#ifdef _WIN32
+		"TEMP"
+#else
+		"TMPDIR"
+#endif
+	);
+	const std::string path = std::string(temporary ? temporary : ".") +
+		"/xm8-fdc-state-" + std::to_string(std::chrono::steady_clock::now()
+			.time_since_epoch().count());
+	FILEIO file;
+	DEVICE *fdc = vm.get_device(11);
+	Require(fdc != nullptr, "the VM must expose its FDC");
+	Require(file.Fopen(const_cast<char *>(path.c_str()), FILEIO_WRITE_BINARY),
+		"open FDC state for writing");
+	fdc->save_state(&file);
+	const auto size = file.Ftell();
+	file.Fclose();
+	Require(!file.HasError(), "write FDC state");
+	std::vector<uint8> current(size);
+	Require(file.Fopen(const_cast<char *>(path.c_str()), FILEIO_READ_BINARY),
+		"open FDC state for reading");
+	file.Fread(current.data(), 1, size);
+	file.Fclose();
+	Require(!file.HasError() && size > 8 && current[0] == 2,
+		"FDC writer must use version 2");
+	// Version 2 added four disk-change bytes before the final DRQ clock.
+	// Seed nonzero flags so the legacy load must clear existing values.
+	for(size_t i = size - 8; i < size - 4; ++i) current[i] = 1;
+	current[size - 4] = 0x78;
+	current[size - 3] = 0x56;
+	current[size - 2] = 0x34;
+	current[size - 1] = 0x12;
+	for(int version : {2, 1, 0, 3}) {
+		auto bytes = current;
+		bytes[0] = version;
+		if(version == 1) bytes.erase(bytes.end() - 8, bytes.end() - 4);
+		Require(file.Fopen(const_cast<char *>(path.c_str()), FILEIO_WRITE_BINARY),
+			"write versioned FDC fixture");
+		file.Fwrite(bytes.data(), 1, bytes.size());
+		file.FputUint32(0xdecafbad);
+		file.Fclose();
+		Require(!file.HasError(), "complete versioned FDC fixture");
+		Require(file.Fopen(const_cast<char *>(path.c_str()), FILEIO_READ_BINARY),
+			"read versioned FDC fixture");
+		const bool loaded = fdc->load_state(&file);
+		Require(loaded == (version == 1 || version == 2),
+			"FDC must accept versions 1 and 2 and reject unknown versions");
+		if(loaded) {
+			Require(file.Ftell() == bytes.size() && file.FgetUint32() == 0xdecafbad,
+				"FDC load must leave the following device state aligned");
+		}
+		file.Fclose();
+		Require(!file.HasError(), "FDC fixture must not encounter I/O errors");
+		if(!loaded) continue;
+		Require(file.Fopen(const_cast<char *>(path.c_str()), FILEIO_WRITE_BINARY),
+			"save restored FDC state");
+		fdc->save_state(&file);
+		file.Fclose();
+		Require(!file.HasError(), "complete restored FDC state");
+		Require(file.Fopen(const_cast<char *>(path.c_str()), FILEIO_READ_BINARY),
+			"inspect restored FDC state");
+		file.Fseek(size - 8, FILEIO_SEEK_SET);
+		for(int i = 0; i < 4; ++i) {
+			Require(file.FgetBool() == (version == 2),
+				"legacy state clears disk-change flags; current state preserves them");
+		}
+		Require(file.FgetUint32() == 0x12345678,
+			"both state versions must restore the DRQ clock");
+		file.Fclose();
+		Require(!file.HasError(), "inspect complete restored FDC state");
+	}
+	Require(std::remove(path.c_str()) == 0, "remove temporary FDC state");
 }
 
 } // namespace
@@ -107,6 +190,8 @@ int main()
 		"the Full Speed-equivalent loop must execute multiple VM frames");
 	Require(frames.count == total_extra_frames,
 		"unpaced consecutive sound cycles must notify once per completed frame");
+
+	CheckFdcStateCompatibility(vm);
 
 	std::puts("event_host_frame_integration_test: PASS");
 	return 0;


### PR DESCRIPTION
旧形式のステートをロードすると、フロッピーディスクコントローラー（UPD765A）の保存形式バージョン1が拒否され、CPUや設定だけが復元された状態でメニューに残っていました。保存時と現在のDIP設定が異なる場合、その後メニューを閉じるとVMが再構築されてリセットされます。

バージョン1と2の両方を読み込めるようにし、バージョン1に存在しない4バイトのディスク交換フラグは「交換なし」で初期化します。保存形式はバージョン2を維持し、未知のバージョンは引き続き拒否します。

検証:
- 実際に問題が発生したスロット1で修正前の読み込み失敗を確認し、修正後はファイル末尾までVM状態の読み込みが成功。
- 回帰テストで両形式の読み込み、交換フラグの復元・初期化、DRQクロックと後続データの読み取り位置、未知バージョンの拒否を確認。
- `ctest --test-dir build-ra -R '^event_host_frame_integration_test$' --output-on-failure` 成功。
- RA有効構成の `xm8` ビルド成功。GUIでの再開確認は未実施。
